### PR TITLE
Missing 'import os' in __init__.py

### DIFF
--- a/xontrib/dalias/__init__.py
+++ b/xontrib/dalias/__init__.py
@@ -1,6 +1,7 @@
 """
 Library of xonsh subprocess specification modifiers e.g. ``$(@json echo '{}')``.
 """
+import os
 from xonsh.built_ins import XSH
 
 try:


### PR DESCRIPTION
Fixes @parts, which gets:

> NameError: name 'os' is not defined

Hi! Thank you for the awesome xontrib! I gave it a star!

Please take a look at my PR that ...

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
